### PR TITLE
Ustaw czarny sidebar i tło hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,21 +12,36 @@ body, h1,h2,h3,h4,h5,h6 {font-family: "Montserrat", sans-serif}
 .w3-row-padding img {margin-bottom: 12px}
 /* Set the width of the sidebar to 120px */
 /* styl klasy */
-.w3-sidebar{  width: 120px;
-  color:#222;
+.w3-sidebar{
+  width: 120px;
+  color: #fff;
+  background-color: #000;
+}
 /* Add a left margin to the "page content" that matches the width of the sidebar (120px) */
 #main {margin-left: 120px}
 /* Remove margins from "page content" on small screens */
 @media only screen and (max-width: 600px) {#main {margin-left: 0}}
-</style>
-</head>
-<body class="hero-bg">
-.hero-bg{
-  color:#222;
+
+.hero-bg {
+  color: #222;
   background:
     linear-gradient(rgba(0,0,0,.45), rgba(0,0,0,.45)),
     url("tło 1.jpg") center/cover no-repeat;
 }
+
+.hero {
+  color: #fff;
+  background:
+    linear-gradient(rgba(0,0,0,.45), rgba(0,0,0,.45)),
+    url("tło 1.jpg") center/cover no-repeat;
+  min-height: 60vh;
+  display: grid;
+  place-items: center;
+  text-align: center;
+}
+</style>
+</head>
+<body class="hero-bg">
 <!-- Icon Bar (Sidebar - hidden on small screens) -->
 <nav class="w3-sidebar w3-bar-block w3-small w3-hide-small w3-center w3-black">
   <!-- Avatar image in top left corner -->
@@ -62,18 +77,7 @@ body, h1,h2,h3,h4,h5,h6 {font-family: "Montserrat", sans-serif}
 <!-- Page Content -->
 <div class="w3-padding-large" id="main">
   <!-- Header/Home -->
-  <header class="w3-container w3-padding-32 w3-center /* tło zdjęciowe + przyciemnienie dla czytelności tekstu */
-.hero{
-  color:#000; /* jasny tekst, bo tło ciemne */
-  background:
-    linear-gradient(rgba(0,0,0,.45), rgba(0,0,0,.45)),
-    url("tło 1.jpg") center/cover no-repeat;
-  /* opcjonalnie wysokość hero: */
-  min-height: 60vh;           /* ~60% wysokości ekranu */
-  display: grid; place-items: center; /* ładne wyśrodkowanie */
-  text-align: center;
-}
-" id="home">
+  <header class="w3-container w3-padding-32 w3-center hero" id="home">
     <h1 class="w3-jumbo"><span class="w3-hide-small">This is</span> Unique Work Studio.</h1>
     <p>nagrania.emisje.montaż.</p>
     <img src="hero.jpg" alt="green screen" class="w3-image" width="992" height="1108">


### PR DESCRIPTION
## Summary
- ustawiono czarne tło oraz jasny tekst w pasku bocznym
- dodano wspólne tło typu hero oparte na obrazie "tło 1.jpg" wraz z przyciemnieniem

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d45a948c7083328a79d39f622d4fd4